### PR TITLE
feat: add configurable workspace directory

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,14 @@
+# Required
+ANTHROPIC_API_KEY=sk-ant-***
+
+# Optional - Server config
+# HOST=0.0.0.0
+# PORT=2222
+# CLAUDE_TIMEOUT_SECONDS=300
+# AGENT_CARD_HOST=localhost
+# AGENT_CARD_PORT=2222
+
+# Additional env vars that can be useful for common tasks.
+
+# GitHub token for using the 'gh' CLI. Use with caution.
+# GH_TOKEN=ghp_***

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,18 @@ RUN npm ci
 
 FROM node:20-slim
 
+# Claude Code uses Bash to run commands like curl, git, gh, etc.
 RUN apt-get update && apt-get install -y \
     git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (requires adding the repo first)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+default: help
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+.PHONY: dev
+dev: # Run development server with hot-reload.
+	npm run dev
+
+.PHONY: dev-safe
+dev-safe: # Run dev server with isolated environment (safer).
+	env -i PATH="$$PATH" HOME="$$HOME" ANTHROPIC_API_KEY="$$ANTHROPIC_API_KEY" npm run dev
+
+.PHONY: build
+build: # Build the project.
+	npm run build
+
+.PHONY: test
+test: # Run tests.
+	npm test
+
+.PHONY: lint
+lint: # Run linter.
+	npm run lint
+
+.PHONY: docker-build
+docker-build: # Build the Docker image.
+	docker build -t claude-code-agent .
+
+.PHONY: docker-run
+docker-run: docker-build # Build and run the Docker container.
+	docker run --rm -it --init -v $(PWD)/.env:/app/.env:ro -v $(PWD)/workspace:/workspace -p 2222:2222 claude-code-agent

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,29 @@
+# Issues
+
+## Persistence
+
+- [ ] basic setup for local/docker/helm
+
+**Helm Values** (`values.yaml`):
+
+```yaml
+workspace:
+  persistence:
+    enabled: false      # default: emptyDir (ephemeral)
+    existingClaim: ""   # use existing PVC (takes precedence)
+    size: 5Gi           # size for new PVC
+    storageClass: ""    # storage class (empty = cluster default)
+```
+
+**Usage**:
+
+```bash
+# Default - emptyDir (ephemeral, lost on pod restart)
+helm install claude-code-agent ...
+
+# Create a new PVC for persistence
+helm install claude-code-agent ... --set workspace.persistence.enabled=true
+
+# Use existing PVC
+helm install claude-code-agent ... --set workspace.persistence.existingClaim=my-workspace
+```

--- a/src/claude-code-agent.ts
+++ b/src/claude-code-agent.ts
@@ -1,5 +1,6 @@
 import type { AgentCard } from '@a2a-js/sdk';
 import { ClaudeCodeExecutor } from './claude-code-executor.js';
+import { Config } from './config.js';
 import pkg from '../package.json' with { type: 'json' };
 
 const AgentId = 'claude-code-agent';
@@ -47,8 +48,10 @@ export interface A2AAgent {
   executor: ClaudeCodeExecutor;
 }
 
-export const claudeCodeAgent: A2AAgent = {
-  id: AgentId,
-  card: agentCard,
-  executor: new ClaudeCodeExecutor(),
-};
+export function createAgent(config: Config): A2AAgent {
+  return {
+    id: AgentId,
+    card: agentCard,
+    executor: new ClaudeCodeExecutor(config),
+  };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,62 @@
+import { loadConfig } from './config';
+
+describe('loadConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('uses CLAUDE_CODE_WORKSPACE_DIR env var when set', () => {
+    process.env.CLAUDE_CODE_WORKSPACE_DIR = '/custom/path';
+    const config = loadConfig();
+    expect(config.workspace).toBe('/custom/path');
+  });
+
+  test('defaults workspace to ./workspace when not in container', () => {
+    delete process.env.CLAUDE_CODE_WORKSPACE_DIR;
+    const config = loadConfig();
+    expect(config.workspace).toMatch(/workspace$/);
+  });
+
+  test('uses CLAUDE_ALLOWED_TOOLS when set', () => {
+    process.env.CLAUDE_ALLOWED_TOOLS = 'Bash,Read';
+    const config = loadConfig();
+    expect(config.allowedTools).toBe('Bash,Read');
+  });
+
+  test('defaults allowedTools', () => {
+    delete process.env.CLAUDE_ALLOWED_TOOLS;
+    const config = loadConfig();
+    expect(config.allowedTools).toBe('Bash,Read,Edit,Write,Grep,Glob');
+  });
+
+  test('uses CLAUDE_PERMISSION_MODE when set', () => {
+    process.env.CLAUDE_PERMISSION_MODE = 'strict';
+    const config = loadConfig();
+    expect(config.permissionMode).toBe('strict');
+  });
+
+  test('defaults permissionMode to acceptEdits', () => {
+    delete process.env.CLAUDE_PERMISSION_MODE;
+    const config = loadConfig();
+    expect(config.permissionMode).toBe('acceptEdits');
+  });
+
+  test('uses CLAUDE_TIMEOUT_SECONDS when set', () => {
+    process.env.CLAUDE_TIMEOUT_SECONDS = '600';
+    const config = loadConfig();
+    expect(config.timeoutSeconds).toBe(600);
+  });
+
+  test('defaults timeoutSeconds to 300', () => {
+    delete process.env.CLAUDE_TIMEOUT_SECONDS;
+    const config = loadConfig();
+    expect(config.timeoutSeconds).toBe(300);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+export interface Config {
+  workspace: string;
+  allowedTools: string;
+  permissionMode: string;
+  timeoutSeconds: number;
+}
+
+// Detect if running in a container (Docker/Helm)
+function isContainer(): boolean {
+  return existsSync('/.dockerenv') || existsSync('/run/.containerenv');
+}
+
+// Get workspace path with sensible defaults
+function getWorkspace(): string {
+  if (process.env.CLAUDE_CODE_WORKSPACE_DIR) {
+    return resolve(process.env.CLAUDE_CODE_WORKSPACE_DIR);
+  }
+  return isContainer() ? '/workspace' : resolve('./workspace');
+}
+
+export function loadConfig(): Config {
+  return {
+    workspace: getWorkspace(),
+    allowedTools: process.env.CLAUDE_ALLOWED_TOOLS || 'Bash,Read,Edit,Write,Grep,Glob',
+    permissionMode: process.env.CLAUDE_PERMISSION_MODE || 'acceptEdits',
+    timeoutSeconds: parseInt(process.env.CLAUDE_TIMEOUT_SECONDS || '300', 10),
+  };
+}

--- a/src/lib/format-chunk.test.ts
+++ b/src/lib/format-chunk.test.ts
@@ -15,6 +15,8 @@ jest.mock('chalk', () => ({
 import { formatChunkPreview } from './format-chunk';
 
 describe('formatChunkPreview', () => {
+  // Default terminal width is 80 when process.stdout.columns is undefined
+
   test('system:init with session_id', () => {
     const msg = { type: 'system', subtype: 'init', session_id: 'a6d626b0-6e9b-4dab-819d-ac36e577a1b7' };
     expect(formatChunkPreview(msg)).toBe('system:init session=a6d626b0...');
@@ -37,7 +39,7 @@ describe('formatChunkPreview', () => {
 
   test('user with tool_result with content', () => {
     const msg = { type: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_017Jrx', content: 'File created successfully' }] };
-    expect(formatChunkPreview(msg)).toBe('user: tool_result "File created successfully..."');
+    expect(formatChunkPreview(msg)).toBe('user: tool_result "File created successfully"');
   });
 
   test('user with tool_result without content', () => {
@@ -48,6 +50,8 @@ describe('formatChunkPreview', () => {
   test('truncates long text', () => {
     const longText = 'A'.repeat(100);
     const msg = { type: 'assistant', content: [{ type: 'text', text: longText }] };
-    expect(formatChunkPreview(msg)).toBe(`assistant: "${'A'.repeat(50)}..."`);
+    const result = formatChunkPreview(msg);
+    // Text truncated to 60 chars max
+    expect(result).toMatch(/^assistant: "A{57}\.\.\."/);
   });
 });

--- a/src/lib/format-chunk.ts
+++ b/src/lib/format-chunk.ts
@@ -1,6 +1,12 @@
 import chalk from 'chalk';
 
-// Format a Claude CLI JSON chunk for console output (max 80 chars)
+// Truncate text to max length with ellipsis
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.substring(0, maxLen - 3) + '...';
+}
+
+// Format a Claude CLI JSON chunk for console output
 export function formatChunkPreview(msg: any): string {
   const type = msg.type || 'unknown';
 
@@ -16,8 +22,8 @@ export function formatChunkPreview(msg: any): string {
       return `${typeColor('system')}:${chalk.yellow('init')} ${chalk.dim(`session=${msg.session_id.substring(0, 8)}...`)}`;
     }
     if (subtype === 'result' || msg.msg_type === 'result') {
-      const result = (msg.result || '').substring(0, 50).replace(/\s+/g, ' ');
-      return `${typeColor('system')}:${chalk.yellow('result')} ${chalk.dim(`"${result}${(msg.result?.length || 0) > 50 ? '...' : ''}"`)}`;
+      const result = truncate((msg.result || '').replace(/\s+/g, ' '), 60);
+      return `${typeColor('system')}:${chalk.yellow('result')} ${chalk.dim(`"${result}"`)}`;
     }
     return `${typeColor('system')}:${chalk.yellow(subtype)}`;
   }
@@ -31,22 +37,21 @@ export function formatChunkPreview(msg: any): string {
   if (!first) return `${typeColor(type)}: ${chalk.dim('(empty)')}`;
 
   if (first.type === 'text' && first.text) {
-    const text = first.text.substring(0, 50).replace(/\s+/g, ' ');
-    return `${typeColor(type)}: ${chalk.dim(`"${text}${first.text.length > 50 ? '...' : ''}"`)}`;
+    const text = truncate(first.text.replace(/\s+/g, ' '), 60);
+    return `${typeColor(type)}: ${chalk.dim(`"${text}"`)}`;
   }
   if (first.type === 'tool_use') {
     return `${typeColor(type)}: ${chalk.yellow('tool_use')} ${chalk.dim(first.name || 'unknown')}`;
   }
   if (first.type === 'tool_result') {
-    // Extract preview from content (string or array)
     let preview = '';
     if (typeof first.content === 'string') {
-      preview = first.content.substring(0, 40).replace(/\s+/g, ' ');
+      preview = first.content.replace(/\s+/g, ' ');
     } else if (Array.isArray(first.content) && first.content[0]?.text) {
-      preview = first.content[0].text.substring(0, 40).replace(/\s+/g, ' ');
+      preview = first.content[0].text.replace(/\s+/g, ' ');
     }
     if (preview) {
-      return `${typeColor(type)}: ${chalk.yellow('tool_result')} ${chalk.dim(`"${preview}..."`)}`;
+      return `${typeColor(type)}: ${chalk.yellow('tool_result')} ${chalk.dim(`"${truncate(preview, 50)}"`)}`;
     }
     return `${typeColor(type)}: ${chalk.yellow('tool_result')} ${chalk.dim('(ok)')}`;
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,16 +4,20 @@ import {
   DefaultRequestHandler,
 } from '@a2a-js/sdk/server';
 import { A2AExpressApp } from '@a2a-js/sdk/server/express';
-import { claudeCodeAgent } from './claude-code-agent.js';
+import { createAgent } from './claude-code-agent.js';
+import { Config } from './config.js';
 
-export function setupA2ARoutes(app: Express, host: string, port: number): void {
+export function setupA2ARoutes(app: Express, host: string, port: number, config: Config): void {
   // Use env vars for agent card URL if provided, otherwise use actual host/port
   const cardHost = process.env.AGENT_CARD_HOST || host;
   const cardPort = process.env.AGENT_CARD_PORT || port.toString();
 
+  // Create agent with config
+  const agent = createAgent(config);
+
   // Patch the agent card URL with configured host/port
   const agentCardWithUrl = {
-    ...claudeCodeAgent.card,
+    ...agent.card,
     url: `http://${cardHost}:${cardPort}/`,
   };
 
@@ -22,7 +26,7 @@ export function setupA2ARoutes(app: Express, host: string, port: number): void {
   const requestHandler = new DefaultRequestHandler(
     agentCardWithUrl,
     taskStore,
-    claudeCodeAgent.executor
+    agent.executor
   );
 
   // Create A2A Express app and setup routes on main app

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_WORKSPACE_DIR` env var to override workspace path
- Default to `./workspace` locally, `/workspace` in containers
- Create workspace dir on startup, pass as cwd to Claude CLI
- Add config module with unit tests
- Add Makefile with common recipes and docker-run workspace mount