### PR TITLE
feat(chart): add envFrom support for external config injection

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,6 +23,18 @@ env:
   # OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
   # OTEL_EXPORTER_OTLP_ENDPOINT: "phoenix-svc.phoenix.svc.cluster.local:4317"
 
+# Environment variables from ConfigMaps/Secrets
+# Useful for injecting configuration from external sources (e.g., OTEL settings)
+# Example:
+#   envFrom:
+#   - configMapRef:
+#       name: otel-environment-variables
+#       optional: true
+#   - secretRef:
+#       name: otel-environment-variables
+#       optional: true
+envFrom: []
+
 # Claude Code configuration via ConfigMaps
 #
 # Create from a directory: kubectl create configmap my-defaults --from-file=./claude-defaults/


### PR DESCRIPTION
## Summary
- Adds `envFrom` field to Helm chart values for injecting environment variables from ConfigMaps/Secrets
- Useful for OTEL auto-injection patterns and other external configuration