### PR TITLE
docs: add OTEL telemetry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,25 @@ docker run -v ./mcp.json:/config/mcp.json:ro \
 
 See [`examples/ark/`](./examples/ark/) for a complete example with MCP servers.
 
+### Telemetry (OpenTelemetry)
+
+Enable OTEL tracing by setting `CLAUDE_CODE_ENABLE_TELEMETRY=1`:
+
+```bash
+# Docker
+docker run -e CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:6006 ...
+
+# Helm
+helm install ... --set env.CLAUDE_CODE_ENABLE_TELEMETRY=1
+
+# With envFrom for OTEL secrets (e.g., from Phoenix)
+helm install ... \
+  --set env.CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+  --set envFrom[0].secretRef.name=otel-environment-variables \
+  --set envFrom[0].secretRef.optional=true
+```
+
 ### Claude Configuration
 
 Optionally mount config files to `/home/claude-code-agent/.claude-defaults/`:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,12 +16,9 @@ apiKeySecret: ""
 env:
   CLAUDE_TIMEOUT_SECONDS: "3600"
   FORCE_COLOR: "1"
-  # OpenTelemetry - uncomment or set in custom values to enable
+  # OpenTelemetry - uncomment to enable tracing
   # CLAUDE_CODE_ENABLE_TELEMETRY: "1"
-  # OTEL_METRICS_EXPORTER: "otlp"
-  # OTEL_LOGS_EXPORTER: "otlp"
-  # OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
-  # OTEL_EXPORTER_OTLP_ENDPOINT: "phoenix-svc.phoenix.svc.cluster.local:4317"
+  # OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-svc.phoenix.svc.cluster.local:6006"  # example
 
 # Environment variables from ConfigMaps/Secrets
 # Useful for injecting configuration from external sources (e.g., OTEL settings)

--- a/examples/ark/values.yaml
+++ b/examples/ark/values.yaml
@@ -22,13 +22,10 @@ env:
   CLAUDE_TIMEOUT_SECONDS: "3600"
   FORCE_COLOR: "1"
   DOCKER_HOST: tcp://localhost:2375
-  # OpenTelemetry - send metrics/traces to Phoenix
+  # OpenTelemetry - send traces to Phoenix (HTTP protocol)
   CLAUDE_CODE_ENABLE_TELEMETRY: "1"
-  OTEL_SERVICE_NAME: claude-code-agent
-  OTEL_METRICS_EXPORTER: otlp
-  OTEL_LOGS_EXPORTER: otlp
-  OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-  OTEL_EXPORTER_OTLP_ENDPOINT: phoenix-svc.phoenix.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-svc.phoenix.svc.cluster.local:6006"
 
 # DinD sidecar for Kind cluster creation
 # DOCKER_TLS_CERTDIR="" disables TLS so DinD listens on port 2375 (non-TLS)


### PR DESCRIPTION
## Summary
- Add Telemetry section to README with usage examples
- Fix OTEL endpoint in values.yaml comments (HTTP on port 6006, not gRPC 4317)
- Simplify examples/ark OTEL config to use correct Phoenix endpoint