### PR TITLE
feat: add YAML config file support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md
+
+## Development Workflow
+
+When developing on this project, `npm run dev` is typically running with hot-reload via tsx. **Do not run `npm run build`** during development - changes are picked up automatically.
+
+## Testing
+
+```bash
+npm test
+```
+
+## Debug Logging
+
+Enable debug output with the `DEBUG` env var:
+
+```bash
+DEBUG=claude-code-agent:* npm run dev
+```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ devspace dev -p ark  # Ark example with DinD for Kind clusters
 
 ## Configuration
 
-### CLI Options
+All options are documented in [`claude-code-agent.example.yaml`](./claude-code-agent.example.yaml). Environment variables from `.env` are loaded on startup (overriding existing vars). The config file `.claude-code-agent.yaml` is loaded by default if present.
 
 ```bash
 claude-code-agent [options] [-- <claude-code-args>]
@@ -140,6 +140,7 @@ Options:
   -p, --port <number>      Server port (default: 2222)
   -H, --host <string>      Server host (default: 0.0.0.0)
   -w, --workspace <path>   Workspace directory
+  -c, --config <path>      Path to YAML config file
   --timeout <seconds>      Execution timeout (default: 3600)
   --log-path <path>        Path to write Claude output logs
   --agent-name <name>      Agent name for A2A registration

--- a/claude-code-agent.example.yaml
+++ b/claude-code-agent.example.yaml
@@ -1,0 +1,69 @@
+# claude-code-agent configuration
+#
+# Configuration values can be set via (in order of precedence):
+#   1. Command line arguments (highest priority)
+#   2. Environment variables
+#   3. This config file
+#   4. Default values (lowest priority)
+#
+# Config file locations (first found is used):
+#   1. Path specified by --config CLI argument
+#   2. Path specified by CLAUDE_CODE_AGENT_CONFIG env var
+#   3. ./.claude-code-agent.yaml (dotfile in current directory)
+#
+# Copy this file to .claude-code-agent.yaml and customize as needed.
+
+# Server configuration
+server:
+  # Host to bind the server to
+  # CLI: --host, -H
+  # Env: HOST
+  # Default: 0.0.0.0
+  host: "0.0.0.0"
+
+  # Port to listen on
+  # CLI: --port, -p
+  # Env: PORT
+  # Default: 2222
+  port: 2222
+
+# Agent configuration
+agent:
+  # Agent name for A2A registration
+  # CLI: --agent-name
+  # Env: CLAUDE_AGENT_NAME
+  # Default: claude-code
+  name: "claude-code"
+
+  # Workspace directory for Claude Code operations
+  # CLI: --workspace, -w
+  # Env: CLAUDE_CODE_WORKSPACE_DIR
+  # Default: ./workspace (or /workspace in containers)
+  workspace: "./workspace"
+
+  # Execution timeout in seconds
+  # CLI: --timeout
+  # Env: CLAUDE_TIMEOUT_SECONDS
+  # Default: 3600 (1 hour)
+  timeout: 3600
+
+# Logging configuration
+logging:
+  # Path to write Claude output logs
+  # CLI: --log-path
+  # Env: CLAUDE_LOG_PATH
+  # Default: null (no logging)
+  path: null
+
+# Claude Code passthrough arguments
+# These args are passed directly to the Claude Code CLI after --
+# CLI args (after --) are appended to config file args
+# Default: [] (empty)
+claudeArgs: []
+
+# Example:
+# claudeArgs:
+#  - "--mcp-config"
+#  - "/config/mcp.json"
+#  - "--allowedTools"
+#  - "Bash,Read"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "dotenv": "^16.4.5",
         "execa": "^9.6.0",
         "express": "^5.1.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "claude-code-agent": "dist/main.js"
@@ -8044,6 +8045,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "dotenv": "^16.4.5",
     "execa": "^9.6.0",
     "express": "^5.1.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,61 +1,178 @@
-import { loadConfig } from './config';
+import { loadConfig, loadConfigFile, CliOptions } from './config';
+import { writeFileSync, unlinkSync } from 'fs';
+
+describe('loadConfigFile', () => {
+  const testConfigPath = './test-config.yaml';
+
+  afterEach(() => {
+    try {
+      unlinkSync(testConfigPath);
+    } catch {
+      // File may not exist
+    }
+  });
+
+  it('should return null when no config file exists', () => {
+    const result = loadConfigFile('./nonexistent.yaml');
+    expect(result).toBeNull();
+  });
+
+  it('should load config from YAML file', () => {
+    writeFileSync(testConfigPath, `
+server:
+  host: "127.0.0.1"
+  port: 3000
+agent:
+  name: "test-agent"
+  workspace: "/test/workspace"
+  timeout: 7200
+logging:
+  path: "/var/log/claude.log"
+claudeArgs:
+  - "--mcp-config"
+  - "/config/mcp.json"
+`);
+
+    const result = loadConfigFile(testConfigPath);
+
+    expect(result).not.toBeNull();
+    expect(result?.server?.host).toBe('127.0.0.1');
+    expect(result?.server?.port).toBe(3000);
+    expect(result?.agent?.name).toBe('test-agent');
+    expect(result?.agent?.workspace).toBe('/test/workspace');
+    expect(result?.agent?.timeout).toBe(7200);
+    expect(result?.logging?.path).toBe('/var/log/claude.log');
+    expect(result?.claudeArgs).toEqual(['--mcp-config', '/config/mcp.json']);
+  });
+
+  it('should skip invalid YAML files', () => {
+    writeFileSync(testConfigPath, 'invalid: yaml: content: [');
+    const result = loadConfigFile(testConfigPath);
+    expect(result).toBeNull();
+  });
+});
 
 describe('loadConfig', () => {
-  const originalEnv = process.env;
+  const testConfigPath = './test-load-config.yaml';
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...originalEnv };
-  });
-
-  afterAll(() => {
-    process.env = originalEnv;
-  });
-
-  test('uses CLAUDE_CODE_WORKSPACE_DIR env var when set', () => {
-    process.env.CLAUDE_CODE_WORKSPACE_DIR = '/custom/path';
-    const config = loadConfig();
-    expect(config.workspace).toBe('/custom/path');
-  });
-
-  test('defaults workspace to ./workspace when not in container', () => {
+    // Reset env vars
+    delete process.env.HOST;
+    delete process.env.PORT;
     delete process.env.CLAUDE_CODE_WORKSPACE_DIR;
-    const config = loadConfig();
-    expect(config.workspace).toMatch(/workspace$/);
-  });
-
-  test('uses CLAUDE_TIMEOUT_SECONDS when set', () => {
-    process.env.CLAUDE_TIMEOUT_SECONDS = '600';
-    const config = loadConfig();
-    expect(config.timeoutSeconds).toBe(600);
-  });
-
-  test('defaults timeoutSeconds to 3600', () => {
     delete process.env.CLAUDE_TIMEOUT_SECONDS;
-    const config = loadConfig();
-    expect(config.timeoutSeconds).toBe(3600);
-  });
-
-  test('uses CLAUDE_LOG_PATH when set', () => {
-    process.env.CLAUDE_LOG_PATH = '/var/log/claude.log';
-    const config = loadConfig();
-    expect(config.logPath).toBe('/var/log/claude.log');
-  });
-
-  test('defaults logPath to null', () => {
     delete process.env.CLAUDE_LOG_PATH;
+    delete process.env.CLAUDE_AGENT_NAME;
+    delete process.env.CLAUDE_CODE_AGENT_CONFIG;
+  });
+
+  afterEach(() => {
+    // Restore env vars
+    process.env = { ...originalEnv };
+    try {
+      unlinkSync(testConfigPath);
+    } catch {
+      // File may not exist
+    }
+  });
+
+  it('should return defaults when no config source exists', () => {
     const config = loadConfig();
+
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.port).toBe(2222);
+    expect(config.timeoutSeconds).toBe(3600);
     expect(config.logPath).toBeNull();
+    expect(config.agentName).toBe('claude-code');
+    expect(config.claudeArgs).toEqual([]);
   });
 
-  test('passes through claudeArgs', () => {
-    const config = loadConfig({}, ['--mcp-config', '/config/claude.json']);
-    expect(config.claudeArgs).toEqual(['--mcp-config', '/config/claude.json']);
-  });
+  it('should load config from file', () => {
+    writeFileSync(testConfigPath, `
+server:
+  host: "10.0.0.1"
+  port: 4000
+agent:
+  name: "file-agent"
+`);
 
-  test('CLI options override env vars', () => {
-    process.env.PORT = '3000';
-    const config = loadConfig({ port: 4000 });
+    const config = loadConfig({ config: testConfigPath });
+
+    expect(config.host).toBe('10.0.0.1');
     expect(config.port).toBe(4000);
+    expect(config.agentName).toBe('file-agent');
+  });
+
+  it('should override file config with env vars', () => {
+    writeFileSync(testConfigPath, `
+server:
+  host: "10.0.0.1"
+  port: 4000
+agent:
+  name: "file-agent"
+`);
+
+    process.env.HOST = '192.168.1.1';
+    process.env.PORT = '5000';
+    process.env.CLAUDE_AGENT_NAME = 'env-agent';
+
+    const config = loadConfig({ config: testConfigPath });
+
+    expect(config.host).toBe('192.168.1.1');
+    expect(config.port).toBe(5000);
+    expect(config.agentName).toBe('env-agent');
+  });
+
+  it('should override env vars with CLI options', () => {
+    writeFileSync(testConfigPath, `
+server:
+  host: "10.0.0.1"
+  port: 4000
+`);
+
+    process.env.HOST = '192.168.1.1';
+    process.env.PORT = '5000';
+
+    const cliOptions: CliOptions = {
+      host: '127.0.0.1',
+      port: 8080,
+      config: testConfigPath,
+    };
+
+    const config = loadConfig(cliOptions);
+
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.port).toBe(8080);
+  });
+
+  it('should merge claudeArgs from file and CLI', () => {
+    writeFileSync(testConfigPath, `
+claudeArgs:
+  - "--mcp-config"
+  - "/config/mcp.json"
+`);
+
+    const config = loadConfig({ config: testConfigPath }, ['--allowedTools', 'Bash']);
+
+    expect(config.claudeArgs).toEqual([
+      '--mcp-config',
+      '/config/mcp.json',
+      '--allowedTools',
+      'Bash',
+    ]);
+  });
+
+  it('should load config from CLAUDE_CODE_AGENT_CONFIG env var', () => {
+    writeFileSync(testConfigPath, `
+server:
+  port: 9999
+`);
+
+    process.env.CLAUDE_CODE_AGENT_CONFIG = testConfigPath;
+
+    const config = loadConfig();
+
+    expect(config.port).toBe(9999);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,25 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { parse as parseYaml } from 'yaml';
 
+// YAML config file structure
+export interface ConfigFile {
+  server?: {
+    host?: string;
+    port?: number;
+  };
+  agent?: {
+    name?: string;
+    workspace?: string;
+    timeout?: number;
+  };
+  logging?: {
+    path?: string | null;
+  };
+  claudeArgs?: string[];
+}
+
+// Runtime config (resolved from all sources)
 export interface Config {
   host: string;
   port: number;
@@ -8,7 +27,7 @@ export interface Config {
   timeoutSeconds: number;
   logPath: string | null;
   agentName: string;
-  claudeArgs: string[];  // Passthrough args for Claude Code (via --)
+  claudeArgs: string[];
 }
 
 export interface CliOptions {
@@ -18,6 +37,7 @@ export interface CliOptions {
   timeout?: number;
   logPath?: string;
   agentName?: string;
+  config?: string;
 }
 
 // Detect if running in a container (Docker/Helm)
@@ -26,24 +46,74 @@ function isContainer(): boolean {
 }
 
 // Get workspace path with sensible defaults
-function getWorkspace(cliWorkspace?: string): string {
+function getWorkspace(cliWorkspace?: string, fileWorkspace?: string): string {
   if (cliWorkspace) {
     return resolve(cliWorkspace);
   }
   if (process.env.CLAUDE_CODE_WORKSPACE_DIR) {
     return resolve(process.env.CLAUDE_CODE_WORKSPACE_DIR);
   }
+  if (fileWorkspace) {
+    return resolve(fileWorkspace);
+  }
   return isContainer() ? '/workspace' : resolve('./workspace');
 }
 
+// Find and load config file
+// Priority: CLI --config > CLAUDE_CODE_AGENT_CONFIG env > ./.claude-code-agent.yaml
+export function loadConfigFile(configPath?: string): ConfigFile | null {
+  const paths = [
+    configPath,
+    process.env.CLAUDE_CODE_AGENT_CONFIG,
+    './.claude-code-agent.yaml',
+  ].filter(Boolean) as string[];
+
+  for (const p of paths) {
+    const resolved = resolve(p);
+    if (existsSync(resolved)) {
+      try {
+        const content = readFileSync(resolved, 'utf-8');
+        return parseYaml(content) as ConfigFile;
+      } catch {
+        // Skip invalid files
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
 export function loadConfig(cliOptions: CliOptions = {}, claudeArgs: string[] = []): Config {
+  // Load config file if available
+  const fileConfig = loadConfigFile(cliOptions.config);
+
   return {
-    host: cliOptions.host || process.env.HOST || '0.0.0.0',
-    port: cliOptions.port || parseInt(process.env.PORT || '2222', 10),
-    workspace: getWorkspace(cliOptions.workspace),
-    timeoutSeconds: cliOptions.timeout || parseInt(process.env.CLAUDE_TIMEOUT_SECONDS || '3600', 10),
-    logPath: cliOptions.logPath || process.env.CLAUDE_LOG_PATH || null,
-    agentName: cliOptions.agentName || process.env.CLAUDE_AGENT_NAME || 'claude-code',
-    claudeArgs,
+    // Server config: CLI > env > file > default
+    host: cliOptions.host
+      || process.env.HOST
+      || fileConfig?.server?.host
+      || '0.0.0.0',
+    port: cliOptions.port
+      || parseInt(process.env.PORT || '', 10)
+      || fileConfig?.server?.port
+      || 2222,
+
+    // Agent config: CLI > env > file > default
+    workspace: getWorkspace(cliOptions.workspace, fileConfig?.agent?.workspace),
+    timeoutSeconds: cliOptions.timeout
+      || parseInt(process.env.CLAUDE_TIMEOUT_SECONDS || '', 10)
+      || fileConfig?.agent?.timeout
+      || 3600,
+    logPath: cliOptions.logPath
+      || process.env.CLAUDE_LOG_PATH
+      || fileConfig?.logging?.path
+      || null,
+    agentName: cliOptions.agentName
+      || process.env.CLAUDE_AGENT_NAME
+      || fileConfig?.agent?.name
+      || 'claude-code',
+
+    // Claude args: config file args first, then CLI args appended
+    claudeArgs: [...(fileConfig?.claudeArgs || []), ...claudeArgs],
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ program
   .option('-p, --port <number>', 'server port', parseInt)
   .option('-H, --host <string>', 'server host')
   .option('-w, --workspace <path>', 'workspace directory')
+  .option('-c, --config <path>', 'path to YAML config file')
   .option('--timeout <seconds>', 'execution timeout in seconds', parseInt)
   .option('--log-path <path>', 'path to write Claude output logs')
   .option('--agent-name <name>', 'agent name for A2A registration')
@@ -72,10 +73,11 @@ const cliOptions: CliOptions = {
   timeout: opts.timeout,
   logPath: opts.logPath,
   agentName: opts.agentName,
+  config: opts.config,
 };
 
-// Load .env file if present
-const dotenvResult = dotenv.config();
+// Load .env file if present (override existing env vars)
+const dotenvResult = dotenv.config({ override: true });
 const loadedEnvVars = dotenvResult.parsed ? Object.keys(dotenvResult.parsed) : [];
 
 // Load configuration (CLI options override env vars)


### PR DESCRIPTION
## Summary
- Add YAML config file support with `--config` CLI option
- Auto-detect `.claude-code-agent.yaml` dotfile in current directory
- Create `claude-code-agent.example.yaml` documenting all config options
- Config precedence: CLI > env vars > config file > defaults
- Add `otel.tracing` section for future experimental tracing options