### PR TITLE
fix: restore error parameter in SpanTransformer.end()

### DIFF
--- a/src/lib/span-transformer.ts
+++ b/src/lib/span-transformer.ts
@@ -280,7 +280,8 @@ export class SpanTransformer {
     }
   }
 
-  end(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  end(_error?: Error): void {
     // No-op - each message creates its own independent span
   }
 }


### PR DESCRIPTION
## Summary
- Restore `_error` parameter in `SpanTransformer.end()` method
- Add eslint-disable comment to suppress unused var warning
- Fixes build error where `claude-code-executor.ts` passes error to `end()`